### PR TITLE
Add spotify auth custom hook

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,4 @@
+frontend/node_modules
+frontend/build/
+frontend/dist/
+frontend/public/

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,11 @@
+{
+    "semi": true,
+    "trailingComma": "es5",
+    "singleQuote": true,
+    "printWidth": 80,
+    "tabWidth": 2,
+    "useTabs": false,
+    "jsxSingleQuote": false,
+    "arrowParens": "always",
+    "endOfLine": "lf"
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
 # CSC308_TeamProject
+
+## Spotify Client Secret and Client ID
+- To run the project, you need to get the client secret and client ID from Spotify (either create a new app at https://developer.spotify.com/dashboard/applications or ask @colter for the client secret and client ID)
+- Once you have the client secret and client ID, create a file called `.env.local` in the frontend directory and add the following lines:
+```
+REACT_APP_CLIENT_ID=<your_client_id>
+REACT_APP_CLIENT_SECRET=<the_client_secret>
+```
+- Note: it is important that the file is called `.env.local` and not `.env` because the client secret and client ID should not be shared on GitHub 👍

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,25 +1,32 @@
 import React from 'react';
 import logo from './logo.svg';
 import './App.css';
+import { SpotifyAuthProvider } from './hooks/useSpotifyAuth';
+import { Profile } from './components/Profile';
 
 function App() {
+  const REDIRECT_URI = 'http://localhost:3000';
+  const AUTH_ENDPOINT = 'https://accounts.spotify.com/authorize';
+  const RESPONSE_TYPE = 'token';
+  const CLIENT_ID = process.env.REACT_APP_CLIENT_ID;
+
   return (
-    <div className="App">
-      <header className="App-header">
-        <img src={logo} className="App-logo" alt="logo" />
-        <p>
-          Edit <code>src/App.tsx</code> and save to reload.
-        </p>
-        <a
-          className="App-link"
-          href="https://reactjs.org"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Learn React
-        </a>
-      </header>
-    </div>
+    <SpotifyAuthProvider>
+      <div className="App">
+        <header className="App-header">
+          <img src={logo} className="App-logo" alt="logo" />
+          <a
+            className="App-link"
+            href={`${AUTH_ENDPOINT}?client_id=${CLIENT_ID}&redirect_uri=${REDIRECT_URI}&response_type=${RESPONSE_TYPE}`}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Login with Spotify
+          </a>
+          <Profile />
+        </header>
+      </div>
+    </SpotifyAuthProvider>
   );
 }
 

--- a/frontend/src/components/Profile.tsx
+++ b/frontend/src/components/Profile.tsx
@@ -1,0 +1,49 @@
+import { FunctionComponent, useState, useEffect } from 'react';
+import { useSpotifyAuth } from '../hooks/useSpotifyAuth';
+
+interface SpotifyProfile {
+  display_name: string;
+  small_image: string;
+  large_image: string;
+}
+
+export const Profile: FunctionComponent = () => {
+  const { token } = useSpotifyAuth();
+  const [profile, setProfile] = useState<SpotifyProfile | null>(null);
+
+  useEffect(() => {
+    if (token) {
+      fetch('https://api.spotify.com/v1/me', {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      })
+        .then((res) => res.json())
+        .then((data) => {
+          if (data.error) {
+            console.error(data.error.message);
+            return;
+          }
+          const profile: SpotifyProfile = {
+            display_name: data.display_name,
+            small_image: data.images?.[0].url,
+            large_image: data.images?.[1].url,
+          };
+          setProfile(profile);
+        });
+    }
+  }, [token]);
+
+  return (
+    <div>
+      {profile ? (
+        <div>
+          <h1>{profile.display_name}</h1>
+          <img src={profile.small_image} alt="Profile Pic🤪" />
+        </div>
+      ) : (
+        <h1>Not logged in</h1>
+      )}
+    </div>
+  );
+};

--- a/frontend/src/hooks/useSpotifyAuth.tsx
+++ b/frontend/src/hooks/useSpotifyAuth.tsx
@@ -1,0 +1,67 @@
+import {
+  createContext,
+  useContext,
+  useState,
+  useEffect,
+  FunctionComponent,
+  ReactNode,
+} from 'react';
+
+interface SpotifyAuthContextType {
+  token: string | null;
+  setToken: React.Dispatch<React.SetStateAction<string | null>>;
+}
+
+const SpotifyAuthContext = createContext<SpotifyAuthContextType>({
+  token: null,
+  setToken: () => {},
+});
+
+export const SpotifyAuthProvider: FunctionComponent<{
+  children: ReactNode;
+}> = ({ children }) => {
+  const [token, setToken] = useState<string | null>(() => {
+    // Load the token from localStorage when the component mounts
+    return localStorage.getItem('spotify_token');
+  });
+
+  useEffect(() => {
+    const hash = window.location.hash;
+    let token = window.localStorage.getItem('token');
+
+    if (!token && hash) {
+      const tokenFragment = hash
+        .substring(1)
+        .split('&')
+        .find((elem) => elem.startsWith('access_token'));
+      if (tokenFragment) {
+        token = tokenFragment.split('=')[1];
+      }
+
+      window.location.hash = '';
+      if (token) {
+        window.localStorage.setItem('token', token);
+      }
+    }
+
+    setToken(token);
+  }, []);
+
+  return (
+    <SpotifyAuthContext.Provider value={{ token, setToken }}>
+      {children}
+    </SpotifyAuthContext.Provider>
+  );
+};
+
+/*
+ * Custom hook to provide access to the auth context
+ * Provides the user's token for use in API requests and the ability to set the token
+ */
+export const useSpotifyAuth = () => {
+  const context = useContext(SpotifyAuthContext);
+  if (!context) {
+    throw new Error('useSpotifyAuth must be used within a SpotifyAuthProvider');
+  }
+  return context;
+};


### PR DESCRIPTION
Basically untested, but allows access to basic calls from the API. Rudimentary profile retrieval implemented as a method of checking whether the spotify api is set up properly.